### PR TITLE
Replace serve with php cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "meow_mates",
   "version": "1.0.0",
   "scripts": {
-    "dev": "concurrently \"npm:tailwind:watch\" \"serve src/\"",
+    "dev": "concurrently \"npm:tailwind:watch\" \"php -S 127.0.0.1:8000 -t ./src\"",
     "format:check": "prettier . --check",
     "format:fix": "prettier . --write",
     "tailwind:watch": "tailwindcss -i ./tailwind.css -o ./src/styles.css --watch --minify",
@@ -13,7 +13,6 @@
     "concurrently": "^8.2.2",
     "prettier": "^3.2.3",
     "prettier-plugin-tailwindcss": "^0.5.11",
-    "serve": "^14.2.1",
     "tailwindcss": "^3.4.1"
   }
 }


### PR DESCRIPTION
Serve was a command to serve all the static files in our `src` directory. Since we're using php, I figured we'd use the php cli to do this and so that we can test the API and other related php files.